### PR TITLE
Fix empty ident name in unit tests under Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,6 @@ language: python
 install:
   - pip install tox
 script:
-  - git config --global user.email "you@example.com"
-  - git config --global user.name "Your Name"
   - tox
 env:
   - TOXENV=py27

--- a/gitflow/branches.py
+++ b/gitflow/branches.py
@@ -271,7 +271,7 @@ class BranchManager(object):
         except GitCommandError as e:
             txt = stdout.getvalue().rstrip()
             if e.stderr:
-                txt = txt + '\n' + e.stderr
+                txt = txt + b'\n' + e.stderr
             raise MergeError(txt)
 
     def delete(self, name, force=False):

--- a/tox.ini
+++ b/tox.ini
@@ -2,6 +2,11 @@
 envlist = py27,py34
 
 [testenv]
+setenv =
+         GIT_COMMITTER_NAME = "Your Name"
+         GIT_COMMITTER_EMAIL = "you@example.com"
+         GIT_AUTHOR_NAME = "Your Name"
+         GIT_AUTHOR_EMAIL = "you@example.com"
 distribute = False
 sitepackages = False
 deps = nose


### PR DESCRIPTION
Travis builds are failing with an error like

`fatal: empty ident name (for <travis@testing-worker-linux-docker-be47e347-3234-linux-8.prod.travis-ci.org>) not allowed`

The `git config --global user.name` and `… user.email` in `.travis.yml` look like they should fix this, but their result isn't visible inside the tests. The GitPython code still sees the name and email, but the git binary doesn't.

Instead of the config file, use the `GIT_COMMITTER_NAME`, `…_EMAIL`, and corresponding `…_AUTHOR_…` environment variables. Tests pass with both py27 and py34.

Also fixed the byte/string mismatch in py34's reporting the above error. Use a byte newline instead of string.
