### PR TITLE
Feature/finish tag exists

### DIFF
--- a/gitflow/branches.py
+++ b/gitflow/branches.py
@@ -423,11 +423,15 @@ class ReleaseBranchManager(BranchManager):
             # In case a previous attempt to finish this release branch
             # has failed, but the tag was set successful, we skip it
             # now.
-            # :todo: check: if tag exists, it must point to the commit
-            tag = gitflow.tag(
-                tagname, self.gitflow.master_name(),
-                **tagging_info)
-            to_push.append(tagname)
+            if tagname not in self.gitflow.repo.tags:
+                tag = gitflow.tag(
+                    tagname, self.gitflow.master_name(),
+                    **tagging_info)
+                to_push.append(tagname)
+            elif self.gitflow.repo.tags[tagname].commit != self.gitflow.master().commit:
+                # if tag exists, it must point to the commit
+                raise TagExistsError('Tag already exists and does not point to %s branch %s'
+                                     % (self.identifier, name))
 
         # merge the master branch back into develop; this makes the
         # master branch - and the new tag (if provided) - a parent of

--- a/tests/helpers/__init__.py
+++ b/tests/helpers/__init__.py
@@ -177,16 +177,26 @@ def git_working_dir(func):
     return set_git_working_dir
 
 
-@git_working_dir
-def fake_commit(repo, message, append=True, filename='newfile.py'):
+def write_file(filename, append, change):
+    """
+    Write the contents of "change" into "filename"
+
+    If "append", append to the end. Else, replace the contents.
+    """
     if append:
         f = open(filename, 'a')
     else:
         f = open(filename, 'w')
     try:
-        f.write('This is a dummy change.\n')
+        f.write(change)
     finally:
         f.close()
+
+
+@git_working_dir
+def fake_commit(repo, message, append=True,
+                filename='newfile.py', change='This is a dummy change.\n'):
+    write_file(filename, append, change)
     repo.index.add([filename])
     return repo.index.commit(message)
 


### PR DESCRIPTION
This fixes a bug in gitflow.branches.ReleaseBranchManager.finish(), and adds a unit test for catching it.

Without the fix, the new test fails (see below). With the fix, all tests pass (not shown).

See the commit messages for more details.

```
$ tox
GLOB sdist-make: /ext/home/rich/git/github.com/locationlabs/gitflow/setup.py
py27 inst-nodeps: /ext/home/rich/git/github.com/locationlabs/gitflow/.tox/dist/nu-gitflow-1.0.1.zip
py27 installed: coverage==4.1,future==0.15.2,gitdb==0.6.4,GitPython==2.0.5,linecache2==1.0.0,nose==1.3.7,nose-cover3==0.1.0,nu-gitflow==1.0.1,six==1.10.0,smmap==0.9.0,traceback2==1.4.0,unittest2==1.1.0
py27 runtests: PYTHONHASHSEED='1353581955'
py27 runtests: commands[0] | nosetests --with-coverage3 --cover-package=gitflow
.............Will try to rebase feature branch 'even' ...
..............Will try to rebase feature branch 'recursion' ...
.Will try to rebase feature branch 'recursion' ...
.Will try to rebase feature branch 'recursion' ...
.Will try to rebase feature branch 'recursion' ...
...............................Using default branch names.
.....Using default branch names.
.........................................................................................................................E........................................................................Trying to pull from 'feat/even' while currently on branch 'devel'.
.Trying to pull from 'feat/even' while currently on branch 'feat/something'.
....Trying to pull from 'feat/my-name-is-irrelevant' while currently on branch 'feat/something'.
.Will try to rebase feature branch 'even' ...
................................
======================================================================
ERROR: finish + tag with merge-conflicts on develop
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/ext/home/rich/git/github.com/locationlabs/gitflow/tests/helpers/__init__.py", line 41, in _inner
    f(self, *args, **kwargs)
  File "/ext/home/rich/git/github.com/locationlabs/gitflow/tests/helpers/__init__.py", line 83, in _inner
    f(self, *args, **kwargs)
  File "/ext/home/rich/git/github.com/locationlabs/gitflow/tests/gitflow/test_branches.py", line 1112, in test_finish_release_merge_conflict_tag
    mgr.finish('1.0', tagging_info=taginfo)
  File "/ext/home/rich/git/github.com/locationlabs/gitflow/gitflow/branches.py", line 429, in finish
    **tagging_info)
  File "/ext/home/rich/git/github.com/locationlabs/gitflow/gitflow/core.py", line 56, in _inner
    return f(self, *args, **kwargs)
  File "/ext/home/rich/git/github.com/locationlabs/gitflow/gitflow/core.py", line 492, in tag
    self.repo.create_tag(tagname, commit, message=message or None, **kwargs)
  File "/ext/home/rich/git/github.com/locationlabs/gitflow/.tox/py27/local/lib/python2.7/site-packages/git/repo/base.py", line 351, in create_tag
    return TagReference.create(self, path, ref, message, force, **kwargs)
  File "/ext/home/rich/git/github.com/locationlabs/gitflow/.tox/py27/local/lib/python2.7/site-packages/git/refs/tag.py", line 80, in create
    repo.git.tag(*args, **kwargs)
  File "/ext/home/rich/git/github.com/locationlabs/gitflow/.tox/py27/local/lib/python2.7/site-packages/git/cmd.py", line 457, in <lambda>
    return lambda *args, **kwargs: self._call_process(name, *args, **kwargs)
  File "/ext/home/rich/git/github.com/locationlabs/gitflow/.tox/py27/local/lib/python2.7/site-packages/git/cmd.py", line 923, in _call_process
    return self.execute(make_call(), **_kwargs)
  File "/ext/home/rich/git/github.com/locationlabs/gitflow/.tox/py27/local/lib/python2.7/site-packages/git/cmd.py", line 707, in execute
    raise GitCommandError(command, status, stderr_value)
GitCommandError: 'git tag -m Tagging version 1.0 v1.0 stable' returned with exit code 128
stderr: 'fatal: tag 'v1.0' already exists'

Name                    Stmts   Miss  Cover
-------------------------------------------
gitflow.py                  9      0   100%
gitflow/bin.py            386     16    96%
gitflow/bin/_init.py       96      4    96%
gitflow/branches.py       176      3    98%
gitflow/core.py           370     10    97%
gitflow/exceptions.py      49      8    84%
gitflow/util.py            16      3    81%
-------------------------------------------
TOTAL                    1102     44    96%
----------------------------------------------------------------------
Ran 298 tests in 56.294s

FAILED (errors=1)
ERROR: InvocationError: '/ext/home/rich/git/github.com/locationlabs/gitflow/.tox/py27/bin/nosetests --with-coverage3 --cover-package=gitflow'
py34 inst-nodeps: /ext/home/rich/git/github.com/locationlabs/gitflow/.tox/dist/nu-gitflow-1.0.1.zip
py34 installed: coverage==4.1,future==0.15.2,gitdb==0.6.4,GitPython==2.0.5,linecache2==1.0.0,nose==1.3.7,nose-cover3==0.1.0,nu-gitflow==1.0.1,six==1.10.0,smmap==0.9.0,traceback2==1.4.0,unittest2==1.1.0
py34 runtests: PYTHONHASHSEED='1353581955'
py34 runtests: commands[0] | nosetests --with-coverage3 --cover-package=gitflow
.............Will try to rebase feature branch 'even' ...
..............Will try to rebase feature branch 'recursion' ...
.Will try to rebase feature branch 'recursion' ...
.Will try to rebase feature branch 'recursion' ...
.Will try to rebase feature branch 'recursion' ...
...............................Using default branch names.
.....Using default branch names.
.........................................................................................................................E........................................................................Trying to pull from 'feat/even' while currently on branch 'devel'.
.Trying to pull from 'feat/even' while currently on branch 'feat/something'.
....Trying to pull from 'feat/my-name-is-irrelevant' while currently on branch 'feat/something'.
.Will try to rebase feature branch 'even' ...
................................
======================================================================
ERROR: finish + tag with merge-conflicts on develop
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/ext/home/rich/git/github.com/locationlabs/gitflow/tests/helpers/__init__.py", line 41, in _inner
    f(self, *args, **kwargs)
  File "/ext/home/rich/git/github.com/locationlabs/gitflow/tests/helpers/__init__.py", line 83, in _inner
    f(self, *args, **kwargs)
  File "/ext/home/rich/git/github.com/locationlabs/gitflow/tests/gitflow/test_branches.py", line 1112, in test_finish_release_merge_conflict_tag
    mgr.finish('1.0', tagging_info=taginfo)
  File "/ext/home/rich/git/github.com/locationlabs/gitflow/gitflow/branches.py", line 429, in finish
    **tagging_info)
  File "/ext/home/rich/git/github.com/locationlabs/gitflow/gitflow/core.py", line 56, in _inner
    return f(self, *args, **kwargs)
  File "/ext/home/rich/git/github.com/locationlabs/gitflow/gitflow/core.py", line 492, in tag
    self.repo.create_tag(tagname, commit, message=message or None, **kwargs)
  File "/ext/home/rich/git/github.com/locationlabs/gitflow/.tox/py34/lib/python3.4/site-packages/git/repo/base.py", line 351, in create_tag
    return TagReference.create(self, path, ref, message, force, **kwargs)
  File "/ext/home/rich/git/github.com/locationlabs/gitflow/.tox/py34/lib/python3.4/site-packages/git/refs/tag.py", line 80, in create
    repo.git.tag(*args, **kwargs)
  File "/ext/home/rich/git/github.com/locationlabs/gitflow/.tox/py34/lib/python3.4/site-packages/git/cmd.py", line 457, in <lambda>
    return lambda *args, **kwargs: self._call_process(name, *args, **kwargs)
  File "/ext/home/rich/git/github.com/locationlabs/gitflow/.tox/py34/lib/python3.4/site-packages/git/cmd.py", line 923, in _call_process
    return self.execute(make_call(), **_kwargs)
  File "/ext/home/rich/git/github.com/locationlabs/gitflow/.tox/py34/lib/python3.4/site-packages/git/cmd.py", line 707, in execute
    raise GitCommandError(command, status, stderr_value)
git.exc.GitCommandError: 'git tag -m Tagging version 1.0 v1.0 stable' returned with exit code 128
stderr: 'fatal: tag 'v1.0' already exists'

Name                    Stmts   Miss  Cover
-------------------------------------------
gitflow.py                  9      0   100%
gitflow/bin.py            386     16    96%
gitflow/bin/_init.py       96      4    96%
gitflow/branches.py       176      3    98%
gitflow/core.py           370      8    98%
gitflow/exceptions.py      49      8    84%
gitflow/util.py            16      3    81%
-------------------------------------------
TOTAL                    1102     42    96%
----------------------------------------------------------------------
Ran 298 tests in 142.514s

FAILED (errors=1)
ERROR: InvocationError: '/ext/home/rich/git/github.com/locationlabs/gitflow/.tox/py34/bin/nosetests --with-coverage3 --cover-package=gitflow'
___________________________________ summary ____________________________________
ERROR:   py27: commands failed
ERROR:   py34: commands failed
(tox)rich@rich-trusty [12:51:36 Tue Jun 07] ~/git/github.com/locationlabs/gitflow
```
